### PR TITLE
Implement .toggle() method

### DIFF
--- a/src/ArgsParser/ArgsExceptions/ToggleArgsException.java
+++ b/src/ArgsParser/ArgsExceptions/ToggleArgsException.java
@@ -1,0 +1,20 @@
+package ArgsParser.ArgsExceptions;
+
+import ArgsParser.ArgsException;
+import ArgsParser.Command;
+
+import java.util.Set;
+
+public class ToggleArgsException extends ArgsException {
+    public ToggleArgsException(Command[] toggle) {
+        super(generateMessage(toggle), false);
+    }
+
+    private static String generateMessage(Command[] toggle) {
+        StringBuilder sb = new StringBuilder("The following commands cannot be combined: ");
+        for (Command c : toggle) {
+            sb.append("\n").append(c);
+        }
+        return sb.toString();
+    }
+}

--- a/src/ArgsParser/Command.java
+++ b/src/ArgsParser/Command.java
@@ -67,4 +67,13 @@ public class Command {
         return status;
     }
 
+    /**
+     * Creates a String identifying this Command instance with full and short name version
+     * @return a String identifying this Command instance with full and short name version
+     */
+    @Override
+    public String toString() {
+        return "[" + fullCommandName + " / " + shortCommandName + "]";
+    }
+
 }

--- a/src/test/TestAddParameterMethods.java
+++ b/src/test/TestAddParameterMethods.java
@@ -1,5 +1,7 @@
 import ArgsParser.*;
 import static org.junit.jupiter.api.Assertions.*;
+
+import ArgsParser.ArgsExceptions.ToggleArgsException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -561,4 +563,15 @@ public class TestAddParameterMethods {
         assertTrue(command3.isProvided());
     }
 
+    @Test
+    public void testToggle() {
+        String[] args = {"comm2"};
+        ArgsParser parser = new ArgsParser();
+        Command comd = parser.addCommand("command", "comm", "command1");
+        Command comd2 = parser.addCommand("command2", "comm2", "command2");
+        parser.toggle(comd, comd2);
+        parser.parse(args);
+
+        assertTrue(comd2.isProvided());
+    }
 }

--- a/src/test/TestArgsExceptions.java
+++ b/src/test/TestArgsExceptions.java
@@ -630,4 +630,21 @@ public class TestArgsExceptions {
             parser.addCommand("hlp", "-h", "");
         });
     }
+
+    @Test
+    public void testToggle() {
+        String[] args = {"comm", "comm2"};
+        ArgsParser parser = new ArgsParser();
+        Command comd = parser.addCommand("command", "comm", "command1");
+        Command comd2 = parser.addCommand("command2", "comm2", "command2");
+        parser.toggle(comd, comd2);
+
+        Exception exception = assertThrows(ToggleArgsException.class, () -> parser.parseUnchecked(args));
+        String expected = """
+                
+                <!> The following commands cannot be combined:\s
+                [command / comm]
+                [command2 / comm2]""";
+        assertEquals(expected, exception.getMessage());
+    }
 }


### PR DESCRIPTION
method allows restricting the usage of commands given to the toggle method to only one of them.